### PR TITLE
UNO R4 WiFi new partition table

### DIFF
--- a/combine.py
+++ b/combine.py
@@ -11,15 +11,17 @@ certsData = open("UNOR4USBBridge/build/esp32-patched.esp32.arduino_unor4wifi_usb
 
 # 0x000000 bootloader
 # 0x008000 partitions
-# 0x00E000 boot_app
-# 0x010000 app
-# 0x330000 spiffs
-# 0x3C0000 certs
+# 0x009000 fws
+# 0x00E000 boot_app/otadata
+# 0x010000 certs
+# 0x050000 app0
+# 0x1E0000 app1
+# 0x370000 spiffs
+# 0x3F0000 nvs
+# 0x3F5000 coredump
 
-# calculate the output binary size, app offset 
-outputSize = 0x3C0000 + len(certsData)
-if (outputSize % 1024):
-	outputSize += 1024 - (outputSize % 1024)
+# calculate the output binary size included nvs
+outputSize = 0x3F5000
 
 # allocate and init to 0xff
 outputData = bytearray(b'\xff') * outputSize
@@ -32,23 +34,37 @@ for i in range(0, len(partitionData)):
 	outputData[0x8000 + i] = partitionData[i]
 
 for i in range(0, len(bootApp)):
-        outputData[0xE000 + i] = bootApp[i]
-
-for i in range(0, len(appData)):
-        outputData[0x10000 + i] = appData[i]
-
-for i in range(0, len(spiffsData)):
-        outputData[0x330000 + i] = spiffsData[i]
+    outputData[0xE000 + i] = bootApp[i]
 
 for i in range(0, len(certsData)):
-	outputData[0x3C0000 + i] = certsData[i]
+    outputData[0x10000 + i] = certsData[i]
 
+for i in range(0, len(appData)):
+    outputData[0x50000 + i] = appData[i]
 
-outputFilename = "UNOR4USBBridge/build/esp32-patched.esp32.arduino_unor4wifi_usb_bridge/S3.bin"
-if (len(sys.argv) > 1):
-	outputFilename = sys.argv[1]
+for i in range(0, len(spiffsData)):
+    outputData[0x370000 + i] = spiffsData[i]
+
+outputFilename = "UNOR4USBBridge/build/esp32-patched.esp32.arduino_unor4wifi_usb_bridge/S3-ALL.bin"
 
 # write out
 with open(outputFilename,"w+b") as f:
 	f.seek(0)
 	f.write(outputData)
+	f.close
+
+outputFilename = "UNOR4USBBridge/build/esp32-patched.esp32.arduino_unor4wifi_usb_bridge/S3-BOOT-APP.bin"
+
+# write out
+with open(outputFilename,"w+b") as f:
+	f.seek(0)
+	f.write(outputData[:0x1E0000])
+	f.close
+
+outputFilename = "UNOR4USBBridge/build/esp32-patched.esp32.arduino_unor4wifi_usb_bridge/S3-APP.bin"
+
+# write out
+with open(outputFilename,"w+b") as f:
+	f.seek(0)
+	f.write(outputData[0xE000:0x1E0000])
+	f.close


### PR DESCRIPTION
Combine script will output 3 files:
* S3-ALL.bin the complete binary file (bootable - starts from address 0x0, it will wipe nvs and spiffs)
* S3-BOOT-APP.bin bootloader + certs + bootapp + app0 (bootable - starts from address 0x0, it will keep nvs and spiffs)
* S3-APP.bin minimal image certs + bootapp +app0 (starts from 0x0E000)