### PR TITLE
UNO R4 WiFi: update partition table (2nd try)

### DIFF
--- a/UNOR4USBBridge/at_handler.h
+++ b/UNOR4USBBridge/at_handler.h
@@ -74,6 +74,8 @@ private:
    std::unordered_map<std::string, std::function<chAT::CommandStatus(chAT::Server&, chAT::ATParser&)>> command_table;
    chAT::Server at_srv;
    HardwareSerial *serial;
+   uint8_t* cert_in_flash_ptr = nullptr;
+   spi_flash_mmap_handle_t cert_in_flash_handle;
 
    CClientWrapper getClient(int sock);
 

--- a/UNOR4USBBridge/cmds_wifi_SSL.h
+++ b/UNOR4USBBridge/cmds_wifi_SSL.h
@@ -7,7 +7,7 @@
 #include "incbin.h"
 INCBIN(x509_crt_bundle, PATH_CERT_BUNDLE);
 #else
-#define ROOT_CERTIFICATES_ADDRESS   (0x3C0000)
+#define ROOT_CERTIFICATES_ADDRESS   (0xB000)
 #endif
 
 #include "at_handler.h"

--- a/UNOR4USBBridge/cmds_wifi_SSL.h
+++ b/UNOR4USBBridge/cmds_wifi_SSL.h
@@ -101,10 +101,16 @@ void CAtHandler::add_cmds_wifi_SSL() {
                #ifdef BUNDLED_CA_ROOT_CRT
                the_client.sslclient->setCACertBundle((const uint8_t *)x509_crt_bundle_data);
                #else
-               const uint8_t* cert_in_flash;
-               static spi_flash_mmap_handle_t t;
-               spi_flash_mmap(ROOT_CERTIFICATES_ADDRESS, 128*1024, SPI_FLASH_MMAP_DATA, (const void**)&cert_in_flash, &t);
-               the_client.sslclient->setCACertBundle((const uint8_t *)cert_in_flash);
+               if(cert_in_flash_ptr == nullptr) {
+                  const esp_partition_t *partition = esp_partition_find_first(ESP_PARTITION_TYPE_DATA, ESP_PARTITION_SUBTYPE_ANY, "cert");
+                  if(partition != nullptr) {
+                     esp_partition_mmap(partition, 0, partition->size, SPI_FLASH_MMAP_DATA, (const void**)&cert_in_flash_ptr, &cert_in_flash_handle);
+                  }
+               }
+
+               if(cert_in_flash_ptr != nullptr) {
+                 the_client.sslclient->setCACertBundle(cert_in_flash_ptr);
+               }
                #endif
                srv.write_response_prompt();
             }

--- a/combine.py
+++ b/combine.py
@@ -11,9 +11,8 @@ certsData = open("UNOR4USBBridge/build/esp32-patched.esp32.arduino_unor4wifi_usb
 
 # 0x000000 bootloader
 # 0x008000 partitions
-# 0x009000 fws
-# 0x00E000 boot_app/otadata
-# 0x010000 certs
+# 0x009000 boot_app/otadata
+# 0x00B000 certs
 # 0x050000 app0
 # 0x1E0000 app1
 # 0x370000 spiffs
@@ -34,10 +33,10 @@ for i in range(0, len(partitionData)):
 	outputData[0x8000 + i] = partitionData[i]
 
 for i in range(0, len(bootApp)):
-    outputData[0xE000 + i] = bootApp[i]
+    outputData[0x9000 + i] = bootApp[i]
 
 for i in range(0, len(certsData)):
-    outputData[0x10000 + i] = certsData[i]
+    outputData[0xB000 + i] = certsData[i]
 
 for i in range(0, len(appData)):
     outputData[0x50000 + i] = appData[i]

--- a/combine.py
+++ b/combine.py
@@ -9,18 +9,18 @@ appData = open("UNOR4USBBridge/build/esp32-patched.esp32.arduino_unor4wifi_usb_b
 spiffsData = open("spiffs/spiffs.bin", "rb").read()
 certsData = open("UNOR4USBBridge/build/esp32-patched.esp32.arduino_unor4wifi_usb_bridge/x509_crt_bundle", "rb").read()
 
-# 0x000000 bootloader
-# 0x008000 partitions
-# 0x009000 boot_app/otadata
-# 0x00B000 certs
-# 0x050000 app0
-# 0x1E0000 app1
-# 0x370000 spiffs
-# 0x3F0000 nvs
-# 0x3F5000 coredump
+# Offset   Size     Name
+# 0x000000 0x008000 bootloader
+# 0x008000 0x001000 partitions
+# 0x009000 0x002000 boot_app/otadata
+# 0x00B000 0x045000 certs
+# 0x050000 0x190000 app0
+# 0x1E0000 0x190000 app1
+# 0x370000 0x080000 spiffs
+# 0x3F0000 0x010000 nvs
 
 # calculate the output binary size included nvs
-outputSize = 0x3F5000
+outputSize = 0x400000
 
 # allocate and init to 0xff
 outputData = bytearray(b'\xff') * outputSize

--- a/export.sh
+++ b/export.sh
@@ -1,6 +1,5 @@
 # modify esp32 platform.txt from g++11 to gcc+17
-rm -f UNOR4USBBridge/build/esp32-patched.esp32.arduino_unor4wifi_usb_bridge/S3.bin
-rm -f UNOR4USBBridge/build/esp32-patched.esp32.arduino_unor4wifi_usb_bridge/x509_crt_bundle
+rm -rf UNOR4USBBridge/build
 echo "Build Sketch"
 ./compile.sh
 echo "Build certificates bundle"


### PR DESCRIPTION
  - Remove fws partition
  - Increase certs partition using fws (thius would allow to load cactr_all.pem + custom certs)
  - Fix load address for app and boot_app binaries
  - Remove coredump and increase nvs