### PR TITLE
Replace firmware restoration instructions with link to duplicate Help Center content

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,7 +49,7 @@ espflash write-bin -b 115200 0x0 S3.bin
 
 ## Update your board
 
-To flash the firmware the board needs to be in `ESP download` mode. This can be done [manually](unor4wifi-updater#option-2) or using the [unor4wifi-updater](unor4wifi-updater) script.
+To flash the firmware the board needs to be in `ESP download` mode. This can be done [manually](https://support.arduino.cc/hc/en-us/articles/9670986058780-Update-the-connectivity-module-firmware-on-UNO-R4-WiFi#espflash) or using the [unor4wifi-updater](unor4wifi-updater) script.
 
 Alternatively you can also use the `download.sh` script to update the firmware using the `arduino-cli`. Also in this case the `download.sh` script
 should be invoked after putting the board in `ESP download` mode.

--- a/unor4wifi-updater/README.md
+++ b/unor4wifi-updater/README.md
@@ -60,22 +60,7 @@ Running the script from the terminal instead of double click should avoid the co
 Disconnect and connect again your UNO R4 WiFi from your PC and re-run the script.
 
 ## Option 2
-Manually put  the UNO R4 WiFi in ESP mode
 
-1. Disconnect the UNO R4 WiFi from your PC
-2. Short the pins highlighted in the image using a jumper wire
+Follow the "**Run espflash directly**" instructions provided in this Arduino Help Center article:
 
-![image](https://github.com/pennam/UnoR4WiFiUpdate/assets/20436476/b271759e-5d7b-44f5-954e-15bc0f7feae9)
-
-3. Connect the UNO R4 WiFi to your PC
-4. From the root folder of the downloaded .zip file run
-
-#### Linux and MacOS
-`./bin/espflash write-bin -b 115200 0x0 firmware/UNOR4-WIFI-S3-0.2.0-rc1.bin`
-
-#### Windows
-`bin\espflash write-bin -b 115200 0x0 firmware\UNOR4-WIFI-S3-0.2.0-rc1.bin`
-
-5. Disconnect your UNO R4 WiFi from your PC
-6. Remove the jumper wire
-7. Connect the board to your PC again and enjoy
+https://support.arduino.cc/hc/en-us/articles/9670986058780-Update-the-connectivity-module-firmware-on-UNO-R4-WiFi#espflash


### PR DESCRIPTION
Unfortunately, the firmware packaging system includes the version number in the firmware binary filename. The exact binary filename is referenced in the firmware restoration instructions, which means that they must be updated on every release or else become obsolete.

Equivalent instructions have also been published in the Arduino Help Center. The fact that the maintainers of both projects have failed to keep their instructions updated through the course of multiple releases and over 6 months shows that is is not feasible to maintain redundant copies of the instructions.

Since these instructions are not directly relevant to the updater scripts, they are not really in scope for the script's readme. The Help Center article is significantly discoverable to the user, slightly higher quality that the variant here, and it makes more sense to put the responsibility for such content on the maintainers of the Help Center. For these reasons, the redundant instructions are removed from this repository, replaced with a link to the Help Center article.

---

I have also submitted an update for the currently obsolete Help Center article: https://github.com/arduino/help-center-content/pull/349