### PR TITLE
[Draft] Implement AT+UART command to change communication baudrate

### DIFF
--- a/UNOR4USBBridge/at_handler.cpp
+++ b/UNOR4USBBridge/at_handler.cpp
@@ -67,9 +67,14 @@ CClientWrapper CAtHandler::getClient(int sock) {
 
 /* -------------------------------------------------------------------------- */
 void CAtHandler::run() {
-/* -------------------------------------------------------------------------- */   
-   at_srv.run();
-   vTaskDelay(1);
+/* -------------------------------------------------------------------------- */
+  at_srv.run();
+  if (at_srv.desiredBaudrate > 0)
+  {
+    serial->begin(at_srv.desiredBaudrate, SERIAL_8N1, 6, 5);
+    at_srv.desiredBaudrate = -1;
+  }
+  vTaskDelay(1);
 }
 
 

--- a/UNOR4USBBridge/chAT.hpp
+++ b/UNOR4USBBridge/chAT.hpp
@@ -117,6 +117,8 @@ namespace SudoMaker::chAT {
 		void write_line_end();
 
 		RunStatus run();
+
+		int desiredBaudrate = -1; // Set this to a positive value to indicate UARD baud rate change is needed.
 	};
 
 	inline Server::RunStatus operator|(Server::RunStatus a, Server::RunStatus b) {

--- a/UNOR4USBBridge/cmds_esp_generic.h
+++ b/UNOR4USBBridge/cmds_esp_generic.h
@@ -21,6 +21,13 @@ void CAtHandler::add_cmds_esp_generic() {
    };
 
    /* ....................................................................... */
+   command_table[_UART] = [this](auto & srv, auto & parser) {
+   /* ....................................................................... */
+      srv.desiredBaudrate = std::stoi(parser.args[0]);
+      return chAT::CommandStatus::OK;
+   };
+
+   /* ....................................................................... */
    command_table[_RESTART_BOOTLOADER] = [this](auto & srv, auto & parser) {
    /* ....................................................................... */
       switch (parser.cmd_mode) {

--- a/UNOR4USBBridge/commands.h
+++ b/UNOR4USBBridge/commands.h
@@ -20,6 +20,7 @@ enum file_op {
 #define _ENDL                    "\r\n" 
 #define _WIFISCAN                "+WIFISCAN"
 
+#define _UART                    "+UART"
 #define _RESET                   "+RESET"
 #define _RESTART_BOOTLOADER      "+RESTARTBOOTLOADER"
 #define _GMR                     "+GMR"


### PR DESCRIPTION
Related to https://github.com/arduino/uno-r4-wifi-usb-bridge/issues/55

This implements the "AT+UART<baudrate>" command to change the baudrate on the fly, keeping the default at 115200. 
While this works in practice, it has side effects due to the fact that, when RESET is pressed on the board, the ESP32 is not reset - thus, it keeps the previously configured speed. This means that if you upload code to change the baudrate, then upload another code that uses a different baudrate, the second code won't work until you reboot the whole board. 

This is not user-friendly, but I don't see a way around it (apart from testing all common baudrate until  getting a valid reply, which isn't really practical). The good thing about this code though is that it's compatible with the current Arduino version: for a standard user who doesn't touch the baudrate, everything still works. Increasing the baudrate would be 'advanced usage' where we assume that the user is aware and ok with this side effect.

However, I would personally be more in favor of changing this baudrate once and for all for a new hard-coded value. Indeed I think that this reboot side effect can be quite annoying, or misleading, to the point where it may prevent its usage (no one will want to package this in their code if they know it creates such side effect) ; keeping the feature as a form of 'low-level advanced usage' means it will likely seldom or never be used. 
The only significant downside of this is that it breaks backward compatibility with version 1.2.0 of https://github.com/arduino/ArduinoCore-renesas. I think this can be handled in a satisfactory way by making a new release of ArduinoCore-renesas that's compatible with both versions (assuming 0.4.2 uses the fastest speed, then we could have ArduinoCore-renesas first try this fast speed, then if it fails revert back to 115200).