### PR TITLE
Update Help Center article links

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,7 +49,7 @@ espflash write-bin -b 115200 0x0 S3.bin
 
 ## Update your board
 
-To flash the firmware the board needs to be in `ESP download` mode. This can be done [manually](https://support.arduino.cc/hc/en-us/articles/9670986058780-Update-the-connectivity-module-firmware-on-UNO-R4-WiFi#espflash) or using the [unor4wifi-updater](unor4wifi-updater) script.
+To flash the firmware the board needs to be in `ESP download` mode. This can be done [manually](https://support.arduino.cc/hc/en-us/articles/16379769332892-Restore-the-USB-connectivity-firmware-on-UNO-R4-WiFi-with-espflash) or using the [unor4wifi-updater](unor4wifi-updater) script.
 
 Alternatively you can also use the `download.sh` script to update the firmware using the `arduino-cli`. Also in this case the `download.sh` script
 should be invoked after putting the board in `ESP download` mode.

--- a/unor4wifi-updater/README.md
+++ b/unor4wifi-updater/README.md
@@ -63,4 +63,4 @@ Disconnect and connect again your UNO R4 WiFi from your PC and re-run the script
 
 Follow the "**Run espflash directly**" instructions provided in this Arduino Help Center article:
 
-https://support.arduino.cc/hc/en-us/articles/9670986058780-Update-the-connectivity-module-firmware-on-UNO-R4-WiFi#espflash
+https://support.arduino.cc/hc/en-us/articles/16379769332892-Restore-the-USB-connectivity-firmware-on-UNO-R4-WiFi-with-espflash


### PR DESCRIPTION
The project documentation contains links to an Arduino Help Center article that provides instructions for flashing the firmware by using the [**espflash**](https://github.com/esp-rs/espflash) tool directly.

At the time those links were added (https://github.com/arduino/uno-r4-wifi-usb-bridge/pull/51), the instructions were in a subsection of an article that covered all methods of updating the firmware. Since that time, the instructions for using the **espflash** tool directly were moved to a dedicated article (https://github.com/arduino/help-center-content/pull/436).

A link was added from the previous article to the new article, so it is still possible for the reader to find the intended content even via the previous link. However, that is inconvenient and prone to user error. So it is best to link directly to the intended content.